### PR TITLE
Fix farm2 button visibility after reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,11 @@
           buyChickenBtn.style.display = buyChickenVisible ? "inline" : "none";
           buyGroundChickenBtn.style.display = buyGroundChickenVisible ? "inline" : "none";
           farmerBtn.style.display = farmerVisible ? "inline" : "none";
-          buyFarm2Btn.style.display = farm2Built ? "none" : "inline";
+          if (farm2Built || progressStage < 5) {
+            buyFarm2Btn.style.display = "none";
+          } else {
+            buyFarm2Btn.style.display = gold >= 1000 ? "inline" : "none";
+          }
           farm2El.style.display = farm2Built ? "block" : "none";
           document.getElementById("container").style.display = farmChickenAssigned ? "none" : "block";
         }


### PR DESCRIPTION
## Summary
- prevent second farm buy button from appearing when progress stage is below 5

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68669cf5e590832bbbb338f589fff0e5